### PR TITLE
fix iOS issues

### DIFF
--- a/src/ios/FilePickerIO.h
+++ b/src/ios/FilePickerIO.h
@@ -4,7 +4,7 @@
 #import <Filestack/Filestack.h>
 #import <FSPicker/FSPicker.h>
 
-@interface FilePickerIO : CDVPlugin
+@interface FilePickerIO : CDVPlugin <FSPickerDelegate>
 
 @property(strong) NSString* callbackId;
 

--- a/src/ios/FilePickerIO.m
+++ b/src/ios/FilePickerIO.m
@@ -72,9 +72,11 @@ FSConfig *config;
             config.storeOptions = storeOptions;
         }
         FSTheme *theme = [FSTheme filestackTheme];
-        FSPickerController *fsPickerController = [[FSPickerController alloc] initWithConfig:config theme:theme];
-        fsPickerController.fsDelegate = self;
-        [self.viewController presentViewController:fsPickerController animated:YES completion:nil];
+        dispatch_async(dispatch_get_main_queue(), ^{
+          FSPickerController *fsPickerController = [[FSPickerController alloc] initWithConfig:config theme:theme];
+          fsPickerController.fsDelegate = self;
+          [self.viewController presentViewController:fsPickerController animated:YES completion:nil];
+        });
         return;
     }];
 }


### PR DESCRIPTION
This PR fix 2 issues on iOS : 
- no delegate on the FilePickerIO interface
- show the filepicker in a different thread to avoid the following error 
  <br />
  `This application is modifying the autolayout engine from a background thread, which can lead to engine corruption and weird crashes. This will cause an exception in a future release.`
