### PR TITLE
Update plugin id to be consistent with package name

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
-    id="com.dbaq.cordova.filepickerio"
+    id="cordova-plugin-filepickerio"
     version="0.0.8">
 
     <name>Filepicker.io</name>


### PR DESCRIPTION
Without this change the `cordova prepare` command seems to fail with: `Failed to fetch plugin com.dbaq.cordova.filepickerio@^0.0.8 via registry`.

Also, this seems to be the way some of the official cordova plugins [are](https://github.com/apache/cordova-plugin-camera/blob/4b99623edab1ab0cbfc3faa98e5f966fa9b3ca19/plugin.xml#L24) [doing](https://github.com/apache/cordova-plugin-geolocation/blob/e74c87ae684c10ef6fbaa9e211087c4d9b9fa7ed/plugin.xml#L24) [it](https://github.com/apache/cordova-plugin-splashscreen/blob/9a6ff2700885cb4a15c96c0439112f3953e28420/plugin.xml#L22).
