### PR TITLE
Add embed attribute to iOS frameworks

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -41,9 +41,9 @@
         </config-file>
         <header-file src="src/ios/FilePickerIO.h"/>
         <source-file src="src/ios/FilePickerIO.m"/>
-        <framework src="src/ios/libs/FSPicker.framework" custom="true"/>
-        <framework src="src/ios/libs/Filestack.framework" custom="true"/>
-        <framework src="src/ios/libs/AFNetworking.framework" custom="true"/>
+        <framework src="src/ios/libs/FSPicker.framework" custom="true" embed="true"/>
+        <framework src="src/ios/libs/Filestack.framework" custom="true" embed="true"/>
+        <framework src="src/ios/libs/AFNetworking.framework" custom="true" embed="true"/>
         <framework src="Foundation.framework" autogen="true"/>
         <framework src="AssetsLibrary.framework" autogen="true"/>
         <framework src="CoreFoundation.framework" autogen="true"/>


### PR DESCRIPTION
`cordova-ios` added support for [embedded frameworks](https://github.com/apache/cordova-ios/commit/9848f0b5779d8cd2818a6c6ee9102bb3cbcc3861) since version `v4.4.0`.

This PR makes use of that and should address #8.